### PR TITLE
Explicitely register CLI commands

### DIFF
--- a/DependencyInjection/AlexDoctrineExtraExtension.php
+++ b/DependencyInjection/AlexDoctrineExtraExtension.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Alex\DoctrineExtraBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+class AlexDoctrineExtraExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('graphviz.xml');
+    }
+}

--- a/Resources/config/graphviz.xml
+++ b/Resources/config/graphviz.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="alex_doctrine_extra.graphviz_command" class="Alex\DoctrineExtraBundle\Command\DoctrineMetadataGraphvizCommand">
+      <tag name="console.command" command="doctrine:mapping:graphviz" />
+    </service>
+  </services>
+</container>


### PR DESCRIPTION
Implicit, automatic registration of CLI commands was deprecated in Symfony 3.4 and will be removed in Symfony 4.0.