### PR TITLE
Make it possible to not include reverse edges

### DIFF
--- a/Command/DoctrineMetadataGraphvizCommand.php
+++ b/Command/DoctrineMetadataGraphvizCommand.php
@@ -4,6 +4,7 @@ namespace Alex\DoctrineExtraBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use Alex\DoctrineExtraBundle\Graphviz\DoctrineMetadataGraph;
@@ -22,6 +23,12 @@ class DoctrineMetadataGraphvizCommand extends ContainerAwareCommand
     {
         $this
             ->setName('doctrine:mapping:graphviz')
+            ->addOption(
+              'no-reverse',
+              null,
+              InputOption::VALUE_NONE,
+              'Do not output "reverse" associations'
+            )
         ;
     }
 
@@ -31,7 +38,9 @@ class DoctrineMetadataGraphvizCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $em = $this->getContainer()->get('doctrine')->getManager();
-        $graph = new DoctrineMetadataGraph($em);
+        $graph = new DoctrineMetadataGraph($em, array(
+          'includeReverseEdges' => !$input->hasOption('no-reverse'),
+        ));
 
         $output->writeln($graph->render());
     }

--- a/Graphviz/DoctrineMetadataGraph.php
+++ b/Graphviz/DoctrineMetadataGraph.php
@@ -14,7 +14,7 @@ use Alom\Graphviz\Digraph;
 
 class DoctrineMetadataGraph extends Digraph
 {
-    public function __construct(ObjectManager $manager)
+    public function __construct(ObjectManager $manager, array $options)
     {
         parent::__construct('G');
 
@@ -23,7 +23,7 @@ class DoctrineMetadataGraph extends Digraph
         ));
         $this->set('rankdir', 'LR');
 
-        $data = $this->createData($manager);
+        $data = $this->createData($manager, $options);
 
         $clusters = array();
 
@@ -67,11 +67,11 @@ class DoctrineMetadataGraph extends Digraph
         }
     }
 
-    private function createData(ObjectManager $manager)
+    private function createData(ObjectManager $manager, array $options)
     {
         $data = array('entities' => array(), 'relations' => array());
         $passes = array(
-            new ImportMetadataPass(),
+            new ImportMetadataPass($options['includeReverseEdges']),
             new InheritancePass(),
         );
 

--- a/Graphviz/Pass/ImportMetadataPass.php
+++ b/Graphviz/Pass/ImportMetadataPass.php
@@ -7,6 +7,13 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 class ImportMetadataPass
 {
+    private $includeReverseEdges;
+
+    public function __construct($includeReverseEdges = true)
+    {
+        $this->includeReverseEdges = $includeReverseEdges;
+    }
+
     public function process(ClassMetadataFactory $factory, $data)
     {
         foreach ($factory->getAllMetadata() as $classMetadata) {
@@ -25,6 +32,12 @@ class ImportMetadataPass
             foreach ($classMetadata->getAssociationMappings() as $name => $mapping) {
                 $field = $mapping['fieldName'];
                 $targetEntity = $mapping['targetEntity'];
+
+                // skip reverse relationships if we are asked to.
+                // reverse relationships are recognized by their 'mappedBy' property.
+                if (!$this->includeReverseEdges && !empty($mapping['mappedBy'])) {
+                    continue;
+                }
 
                 $type = '';
                 switch ($mapping['type']) {


### PR DESCRIPTION
Reverse edges are optional in Doctrine (so all entities don't have them) and crowd the generated graphs, so it is handy to be able to disable them.