### PR TITLE
Run the command without being ContainerAware

### DIFF
--- a/Command/DoctrineMetadataGraphvizCommand.php
+++ b/Command/DoctrineMetadataGraphvizCommand.php
@@ -2,7 +2,8 @@
 
 namespace Alex\DoctrineExtraBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -14,8 +15,20 @@ use Alex\DoctrineExtraBundle\Graphviz\DoctrineMetadataGraph;
  *
  * @author Alexandre Salomé <alexandre.salome@gmail.com>
  */
-class DoctrineMetadataGraphvizCommand extends ContainerAwareCommand
+class DoctrineMetadataGraphvizCommand extends Command
 {
+    /**
+     * @var ManagerRegistry
+     */
+    private $doctrine;
+
+    public function __construct(ManagerRegistry $doctrine)
+    {
+        parent::__construct();
+
+        $this->doctrine = $doctrine;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -37,11 +50,13 @@ class DoctrineMetadataGraphvizCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $em = $this->getContainer()->get('doctrine')->getManager();
+        $em = $this->doctrine->getManager();
         $graph = new DoctrineMetadataGraph($em, array(
           'includeReverseEdges' => !$input->hasOption('no-reverse'),
         ));
 
         $output->writeln($graph->render());
+
+        return 0;
     }
 }

--- a/Graphviz/DoctrineMetadataGraph.php
+++ b/Graphviz/DoctrineMetadataGraph.php
@@ -14,7 +14,7 @@ use Alom\Graphviz\Digraph;
 
 class DoctrineMetadataGraph extends Digraph
 {
-    public function __construct(ObjectManager $manager, array $options)
+    public function __construct(ObjectManager $manager, array $options = array())
     {
         parent::__construct('G');
 
@@ -22,6 +22,11 @@ class DoctrineMetadataGraph extends Digraph
             'shape' => 'record'
         ));
         $this->set('rankdir', 'LR');
+
+        $options = array_merge(
+            array('includeReverseEdges' => true),
+            $options
+        );
 
         $data = $this->createData($manager, $options);
 

--- a/Resources/config/graphviz.xml
+++ b/Resources/config/graphviz.xml
@@ -5,6 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
     <service id="alex_doctrine_extra.graphviz_command" class="Alex\DoctrineExtraBundle\Command\DoctrineMetadataGraphvizCommand">
+      <argument type="service" id="doctrine" />
       <tag name="console.command" command="doctrine:mapping:graphviz" />
     </service>
   </services>

--- a/Tests/Graphviz/DoctrineMetadataGraphTest.php
+++ b/Tests/Graphviz/DoctrineMetadataGraphTest.php
@@ -7,8 +7,9 @@ use Alex\DoctrineExtraBundle\Tests\AbstractTest;
 use Alex\DoctrineExtraBundle\Tests\Sample;
 use Alom\Graphviz\Node;
 use Alom\Graphviz\Subgraph;
+use PHPUnit\Framework\TestCase;
 
-class DoctrineMetadataGraphTest extends \PHPUnit_Framework_TestCase
+class DoctrineMetadataGraphTest extends TestCase
 {
     public function testSimple()
     {

--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,8 @@
     "require": {
         "doctrine/orm": "~2.3",
         "alom/graphviz": "~1.1"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^8.5"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,6 @@
     convertWarningsToExceptions = "true"
     processIsolation            = "false"
     stopOnFailure               = "false"
-    syntaxCheck                 = "false"
     bootstrap                   = "vendor/autoload.php" >
 
     <testsuites>


### PR DESCRIPTION
The ContainerAwareCommand is currently removed from Symfony and is not needed to run this command.